### PR TITLE
Improve battery display message

### DIFF
--- a/new-tab/battery-display.js
+++ b/new-tab/battery-display.js
@@ -13,25 +13,29 @@ class BatteryDisplay {
 
     async render() {
         let battery = await this.getBattery()
+        let secsLeft = Math.min(battery.chargingTime, battery.dischargingTime)
 
         this.element.textContent = [
-            this.getPercentMessage(battery),
-            this.getChargingMessage(battery),
-            this.getTimeMessage(battery)
-        ].join(" ~ ");
+            this.getPercentMessage(battery, secsLeft),
+            this.getChargingMessage(battery, secsLeft),
+            this.getTimeMessage(battery, secsLeft)
+        ].filter(v => typeof v != "undefined").join(" ~ ");
     }
 
-    getPercentMessage(battery) {
+    getPercentMessage(battery, secsLeft) {
+        if (battery.charging && secsLeft == Infinity) return "Battery full";
         return `Battery: ${Math.round(battery.level * 100)}%`
     }
 
-    getChargingMessage(battery) {
+    getChargingMessage(battery, secsLeft) {
+        if (battery.charging && secsLeft == Infinity) return;
         return battery.charging ? "Charging" : "Not charging"
     }
 
-    getTimeMessage(battery) {
-        let secsLeft = Math.min(battery.chargingTime, battery.dischargingTime)
+    getTimeMessage(battery, secsLeft) {
         let direction = battery.charging ? "full" : "empty"
+
+        if (secsLeft == Infinity) return;
 
         let hoursLeft = Math.floor(secsLeft / 3600)
         let minsLeft = Math.floor(secsLeft % 3600 / 60);


### PR DESCRIPTION
The battery message now says "Full" instead of "100%" and the charging message disappears, both when appropriate